### PR TITLE
feat: improve UI consistency with system applets

### DIFF
--- a/src/applet.rs
+++ b/src/applet.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use cosmic::app::{Core, Task};
+use cosmic::cosmic_theme::palette::WithAlpha;
 use cosmic::iced::{stream, Background, Border, Subscription};
 use cosmic::iced_widget::svg::Style as SvgStyle;
 use cosmic::theme::Theme;
@@ -91,7 +92,7 @@ impl Application for PrivacyIndicator {
         }
 
         let icon_style = Rc::new(|theme: &Theme| SvgStyle {
-            color: Some(theme.cosmic().accent_text_color().into()),
+            color: Some(theme.cosmic().button_color().into()),
         });
         let indicator = |name: &str| {
             icon(icon::from_name(name).into())
@@ -112,7 +113,9 @@ impl Application for PrivacyIndicator {
         let container_style = |theme: &Theme| {
             let cosmic = theme.cosmic();
             ContainerStyle {
-                background: Some(Background::Color(cosmic.primary.base.into())),
+                background: Some(Background::Color(
+                    cosmic.primary.base.with_alpha(0.3).into(),
+                )),
                 border: Border {
                     radius: cosmic.corner_radii.radius_xl.into(),
                     ..Default::default()


### PR DESCRIPTION
This pull request adds transparency to container color to make it blend with the panel while keeping the visibility of container. Also changed color of icons to match system applet icons.

The objective of this pull request it to make this applet blend into existing UI.

Before
![Screenshot_2025-03-28_11-16-19](https://github.com/user-attachments/assets/6e4f0ce5-d159-4518-9f4e-f688be8f8a50)
![Screenshot_2025-03-28_11-16-35](https://github.com/user-attachments/assets/f2afc51e-0eaf-4f02-968d-9ab60b95c1e0)

After
![Screenshot_2025-03-28_11-35-32](https://github.com/user-attachments/assets/93df2714-19f9-4966-ab5c-b7d9b993780c)
![Screenshot_2025-03-28_11-35-46](https://github.com/user-attachments/assets/f48e379e-df89-49c9-a6a0-52962aef400b)
