### PR TITLE
feat: add opt-in local audit log for privacy events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ dependencies = [
  "bimap",
  "cosmic-time",
  "inotify",
+ "jiff",
  "libcosmic",
  "nix",
  "pipewire",
@@ -1929,9 +1930,9 @@ checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glow"
@@ -1965,7 +1966,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2838,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
 
 [[package]]
 name = "libcosmic"
@@ -4969,9 +4970,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6691,18 +6692,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Privacy indicator for the COSMIC Desktop"
 bimap = "0.6.3"
 cosmic-time = { git = "https://github.com/D-Brox/cosmic-time.git" }
 inotify = "0.11.0"
+jiff = "0.2"
 nix = { version = "0.31.3", features = ["signal"] }
 pipewire = "0.10.0"
 serde = "1.0.228"

--- a/src/applet.rs
+++ b/src/applet.rs
@@ -4,12 +4,14 @@ use nix::sys::signal::{Signal, kill};
 use nix::unistd::Pid;
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::PathBuf,
     rc::Rc,
     sync::{LazyLock, OnceLock},
     time::{Duration, Instant},
 };
+
+use jiff::Zoned;
 
 use cosmic::{
     Application, Apply, Element,
@@ -27,17 +29,14 @@ use cosmic::{
     surface::action::{LiveSettings, app_popup, destroy_popup},
     theme::{Container, Svg, Theme},
     widget::{
-        Column, Row, button, checkbox, container::Style as CtnStyle, divider, icon,
-        layer_container, mouse_area, svg::Style as SvgStyle, text,
+        Column, Row, button, container::Style as CtnStyle, divider, icon, layer_container,
+        mouse_area, svg::Style as SvgStyle, text,
     },
 };
 use cosmic_time::{Timeline, anim, chain};
 
 use inotify::EventMask;
 use pipewire::{channel::Sender as PwSender, context::ContextRc, main_loop::MainLoopRc};
-
-use cosmic::cosmic_config::CosmicConfigEntry;
-use jiff::Zoned;
 
 use crate::{
     CONFIG_VERSION, Config,
@@ -46,7 +45,7 @@ use crate::{
 };
 
 static REC_ICON: LazyLock<crate::rec_icon::Id> = LazyLock::new(crate::rec_icon::Id::unique);
-static PW_SENDER: OnceLock<PwSender<u32>> = OnceLock::new();
+static PW_SENDER: OnceLock<PwSender<PwId>> = OnceLock::new();
 
 #[derive(Debug, Clone, Default)]
 pub struct AppInfo<'s> {
@@ -61,39 +60,48 @@ struct Shared {
     pub camera: bool,
 }
 
+type PwId = u32;
+type CamId = (PathBuf, u32); // pid: u32
+
+struct Share {
+    name: String,
+    start: Zoned,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CameraShares {
+    pub shares: i32,
+    pub min: i32,
+}
+
 #[derive(Default)]
 pub struct PrivacyIndicator {
     core: Core,
     timeline: Timeline,
     shared: Shared,
-    microphones: HashMap<u32, String>,
-    screenshares: HashMap<u32, String>,
-    cameras: HashMap<PathBuf, (i32, i32)>,
-    /// Start time of each active PipeWire node (mic/screenshare), keyed by node id.
-    pw_starts: HashMap<u32, Zoned>,
-    /// Start time and app name of each in-use camera, keyed by device path.
-    camera_active: HashMap<PathBuf, (Zoned, String)>,
+    microphones: HashMap<PwId, Share>,
+    screenshares: HashMap<PwId, Share>,
+    cameras: HashMap<CamId, Share>,
+    camera_shares: HashMap<PathBuf, CameraShares>,
     popup: Option<PopupId>,
     config: Config,
-    config_handler: Option<cosmic_config::Config>,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
     Tick,
     RecTick(Instant),
-    ScreenShareAdd(u32, String),
-    MicrophoneAdd(u32, String),
-    PipeWireNodeRemove(u32),
+    ScreenShareAdd(PwId, String),
+    MicrophoneAdd(PwId, String),
+    PipeWireNodeRemove(PwId),
     CameraOpen(PathBuf),
     CameraClose(PathBuf),
-    CameraPrevious(HashMap<PathBuf, (i32, i32)>),
+    CameraPrevious(HashMap<PathBuf, CameraShares>),
     CameraReset(PathBuf),
-    DisconnectNode(u32),
+    DisconnectNode(PwId),
     TogglePopup,
     ClosePopup(PopupId),
-    KillProcess(u32),
-    ToggleAuditLog(bool),
+    KillProcess(u32), // PwId or pid
     Config(Config),
 }
 
@@ -122,7 +130,6 @@ impl Application for PrivacyIndicator {
             core,
             timeline,
             config: flags,
-            config_handler: cosmic_config::Config::new(Self::APP_ID, CONFIG_VERSION).ok(),
             ..Default::default()
         };
 
@@ -216,21 +223,21 @@ impl Application for PrivacyIndicator {
         let microphones: Vec<_> = self
             .microphones
             .iter()
-            .map(|(&id, name)| AppInfo {
-                name: name.into(),
+            .map(|(&id, pws)| AppInfo {
+                name: (&pws.name).into(),
                 id,
             })
             .collect();
         let screenshares: Vec<_> = self
             .screenshares
             .iter()
-            .map(|(&id, name)| AppInfo {
-                name: name.into(),
+            .map(|(&id, pws)| AppInfo {
+                name: (&pws.name).into(),
                 id,
             })
             .collect();
         let cameras: Vec<_> = self
-            .cameras
+            .camera_shares
             .keys()
             .flat_map(|path| procs_using_camera(path))
             .collect();
@@ -268,23 +275,13 @@ impl Application for PrivacyIndicator {
         section!("Microphone", microphones, DisconnectNode);
         section!("Screen Share", screenshares, DisconnectNode);
 
-        if !rows.is_empty() {
-            rows.push(divider::horizontal::default().into());
-        }
-        rows.push(
-            padded_control(
-                checkbox("Audit log", self.config.audit_log)
-                    .on_toggle(Message::ToggleAuditLog),
-            )
-            .into(),
-        );
-
         self.core
             .applet
             .popup_container(Column::with_children(rows))
             .into()
     }
 
+    #[allow(clippy::too_many_lines)]
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
         match message {
             Message::Tick => {
@@ -292,83 +289,92 @@ impl Application for PrivacyIndicator {
                     microphone: !self.microphones.is_empty(),
                     screenshare: !self.screenshares.is_empty(),
                     camera: self
-                        .cameras
+                        .camera_shares
                         .values()
-                        .fold(0, |acc, (shares, min)| acc + shares - min)
+                        .fold(0, |acc, CameraShares { shares, min }| acc + shares - min)
                         > 0,
                 };
             }
             Message::CameraPrevious(cameras) => {
-                self.cameras = cameras;
+                self.camera_shares = cameras;
             }
             Message::CameraOpen(path) => {
                 let v = self
-                    .cameras
+                    .camera_shares
                     .entry(path.clone())
-                    .and_modify(|v| v.0 += 1)
-                    .or_insert((1, 0));
-                let in_use = v.0 - v.1 > 0;
-                // On the transition to "in use", open an audit session and
-                // resolve which application opened the device.
-                if self.config.audit_log && in_use && !self.camera_active.contains_key(&path) {
-                    let name = procs_using_camera(&path)
-                        .into_iter()
-                        .next()
-                        .map(|a| a.name.into_owned())
-                        .unwrap_or_else(|| "unknown".to_string());
-                    self.camera_active.insert(path.clone(), (Zoned::now(), name));
+                    .and_modify(|v| v.shares += 1)
+                    .or_insert(CameraShares { shares: 1, min: 0 });
+                let in_use = v.shares - v.min > 0;
+                if self.config.audit_log && in_use {
+                    for app in procs_using_camera(&path) {
+                        self.cameras.entry((path.clone(), app.id)).or_insert(Share {
+                            name: app.name.into_owned(),
+                            start: Zoned::now(),
+                        });
+                    }
                 }
             }
             Message::CameraClose(path) => {
-                let v = self
-                    .cameras
-                    .entry(path.clone())
-                    .and_modify(|v| {
-                        v.0 -= 1;
-                        v.1 = v.1.min(v.0);
-                    })
-                    .or_insert((0, 0));
-                let in_use = v.0 - v.1 > 0;
-                // On the transition back to "not in use", close the session.
-                if !in_use && let Some((start, name)) = self.camera_active.remove(&path) {
-                    if self.config.audit_log {
-                        audit::record(DeviceKind::Camera, &name, &start, &Zoned::now());
+                let shares = self.camera_shares.get_mut(&path).expect("unknown device");
+                shares.shares -= 1;
+                shares.min = shares.min.min(shares.shares);
+                let current: HashSet<u32> = procs_using_camera(&path)
+                    .into_iter()
+                    .map(|a| a.id)
+                    .collect();
+                self.cameras.retain(|(p, pid), Share { name, start }| {
+                    if p != &path {
+                        return true;
                     }
-                }
+                    if current.contains(pid) {
+                        return true;
+                    }
+                    if self.config.audit_log {
+                        audit::record(DeviceKind::Camera, name, start, &Zoned::now());
+                    }
+                    false
+                });
             }
             Message::CameraReset(path) => {
-                // Device removed while still open: close any open session.
-                if let Some((start, name)) = self.camera_active.remove(&path) {
-                    if self.config.audit_log {
-                        audit::record(DeviceKind::Camera, &name, &start, &Zoned::now());
+                self.cameras.retain(|(p, _), Share { name, start }| {
+                    if p != &path {
+                        return true;
                     }
-                }
-                self.cameras.remove(&path);
+                    if self.config.audit_log {
+                        audit::record(DeviceKind::Camera, name, start, &Zoned::now());
+                    }
+                    false
+                });
+                self.camera_shares.remove(&path);
             }
             Message::ScreenShareAdd(id, info) => {
-                if self.config.audit_log {
-                    self.pw_starts.entry(id).or_insert_with(Zoned::now);
-                }
-                self.screenshares.insert(id, info);
+                self.screenshares.insert(
+                    id,
+                    Share {
+                        name: info,
+                        start: Zoned::now(),
+                    },
+                );
             }
             Message::MicrophoneAdd(id, info) => {
-                if self.config.audit_log {
-                    self.pw_starts.entry(id).or_insert_with(Zoned::now);
-                }
-                self.microphones.insert(id, info);
+                self.microphones.insert(
+                    id,
+                    Share {
+                        name: info,
+                        start: Zoned::now(),
+                    },
+                );
             }
             Message::PipeWireNodeRemove(id) => {
-                let start = self.pw_starts.remove(&id);
-                if self.config.audit_log && let Some(start) = start {
-                    let now = Zoned::now();
-                    if let Some(name) = self.screenshares.get(&id) {
-                        audit::record(DeviceKind::ScreenShare, name, &start, &now);
-                    } else if let Some(name) = self.microphones.get(&id) {
-                        audit::record(DeviceKind::Microphone, name, &start, &now);
-                    }
+                if let Some(pw) = self.screenshares.remove(&id)
+                    && self.config.audit_log
+                {
+                    audit::record(DeviceKind::ScreenShare, &pw.name, &pw.start, &Zoned::now());
+                } else if let Some(pw) = self.microphones.remove(&id)
+                    && self.config.audit_log
+                {
+                    audit::record(DeviceKind::Microphone, &pw.name, &pw.start, &Zoned::now());
                 }
-                self.screenshares.remove(&id);
-                self.microphones.remove(&id);
             }
             Message::RecTick(now) => {
                 self.timeline.now(now);
@@ -407,14 +413,6 @@ impl Application for PrivacyIndicator {
             Message::KillProcess(pid) => {
                 if let Err(e) = kill(Pid::from_raw(pid.cast_signed()), Signal::SIGTERM) {
                     println!("Failed to kill process {pid}: {e}");
-                }
-            }
-            Message::ToggleAuditLog(enabled) => {
-                self.config.audit_log = enabled;
-                if let Some(handler) = &self.config_handler
-                    && let Err(e) = self.config.write_entry(handler)
-                {
-                    println!("Failed to save audit_log config: {e:?}");
                 }
             }
             Message::Config(config) => self.config = config,

--- a/src/applet.rs
+++ b/src/applet.rs
@@ -27,8 +27,8 @@ use cosmic::{
     surface::action::{LiveSettings, app_popup, destroy_popup},
     theme::{Container, Svg, Theme},
     widget::{
-        Column, Row, button, container::Style as CtnStyle, divider, icon, layer_container,
-        mouse_area, svg::Style as SvgStyle, text,
+        Column, Row, button, checkbox, container::Style as CtnStyle, divider, icon,
+        layer_container, mouse_area, svg::Style as SvgStyle, text,
     },
 };
 use cosmic_time::{Timeline, anim, chain};
@@ -36,8 +36,12 @@ use cosmic_time::{Timeline, anim, chain};
 use inotify::EventMask;
 use pipewire::{channel::Sender as PwSender, context::ContextRc, main_loop::MainLoopRc};
 
+use cosmic::cosmic_config::CosmicConfigEntry;
+use jiff::Zoned;
+
 use crate::{
     CONFIG_VERSION, Config,
+    audit::{self, DeviceKind},
     camera::{get_inotify, open_cameras, procs_using_camera},
 };
 
@@ -65,8 +69,13 @@ pub struct PrivacyIndicator {
     microphones: HashMap<u32, String>,
     screenshares: HashMap<u32, String>,
     cameras: HashMap<PathBuf, (i32, i32)>,
+    /// Start time of each active PipeWire node (mic/screenshare), keyed by node id.
+    pw_starts: HashMap<u32, Zoned>,
+    /// Start time and app name of each in-use camera, keyed by device path.
+    camera_active: HashMap<PathBuf, (Zoned, String)>,
     popup: Option<PopupId>,
     config: Config,
+    config_handler: Option<cosmic_config::Config>,
 }
 
 #[derive(Debug, Clone)]
@@ -84,6 +93,7 @@ pub enum Message {
     TogglePopup,
     ClosePopup(PopupId),
     KillProcess(u32),
+    ToggleAuditLog(bool),
     Config(Config),
 }
 
@@ -112,6 +122,7 @@ impl Application for PrivacyIndicator {
             core,
             timeline,
             config: flags,
+            config_handler: cosmic_config::Config::new(Self::APP_ID, CONFIG_VERSION).ok(),
             ..Default::default()
         };
 
@@ -257,6 +268,17 @@ impl Application for PrivacyIndicator {
         section!("Microphone", microphones, DisconnectNode);
         section!("Screen Share", screenshares, DisconnectNode);
 
+        if !rows.is_empty() {
+            rows.push(divider::horizontal::default().into());
+        }
+        rows.push(
+            padded_control(
+                checkbox("Audit log", self.config.audit_log)
+                    .on_toggle(Message::ToggleAuditLog),
+            )
+            .into(),
+        );
+
         self.core
             .applet
             .popup_container(Column::with_children(rows))
@@ -280,30 +302,71 @@ impl Application for PrivacyIndicator {
                 self.cameras = cameras;
             }
             Message::CameraOpen(path) => {
-                self.cameras
+                let v = self
+                    .cameras
                     .entry(path.clone())
                     .and_modify(|v| v.0 += 1)
                     .or_insert((1, 0));
+                let in_use = v.0 - v.1 > 0;
+                // On the transition to "in use", open an audit session and
+                // resolve which application opened the device.
+                if self.config.audit_log && in_use && !self.camera_active.contains_key(&path) {
+                    let name = procs_using_camera(&path)
+                        .into_iter()
+                        .next()
+                        .map(|a| a.name.into_owned())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    self.camera_active.insert(path.clone(), (Zoned::now(), name));
+                }
             }
             Message::CameraClose(path) => {
-                self.cameras
+                let v = self
+                    .cameras
                     .entry(path.clone())
                     .and_modify(|v| {
                         v.0 -= 1;
                         v.1 = v.1.min(v.0);
                     })
                     .or_insert((0, 0));
+                let in_use = v.0 - v.1 > 0;
+                // On the transition back to "not in use", close the session.
+                if !in_use && let Some((start, name)) = self.camera_active.remove(&path) {
+                    if self.config.audit_log {
+                        audit::record(DeviceKind::Camera, &name, &start, &Zoned::now());
+                    }
+                }
             }
             Message::CameraReset(path) => {
+                // Device removed while still open: close any open session.
+                if let Some((start, name)) = self.camera_active.remove(&path) {
+                    if self.config.audit_log {
+                        audit::record(DeviceKind::Camera, &name, &start, &Zoned::now());
+                    }
+                }
                 self.cameras.remove(&path);
             }
             Message::ScreenShareAdd(id, info) => {
+                if self.config.audit_log {
+                    self.pw_starts.entry(id).or_insert_with(Zoned::now);
+                }
                 self.screenshares.insert(id, info);
             }
             Message::MicrophoneAdd(id, info) => {
+                if self.config.audit_log {
+                    self.pw_starts.entry(id).or_insert_with(Zoned::now);
+                }
                 self.microphones.insert(id, info);
             }
             Message::PipeWireNodeRemove(id) => {
+                let start = self.pw_starts.remove(&id);
+                if self.config.audit_log && let Some(start) = start {
+                    let now = Zoned::now();
+                    if let Some(name) = self.screenshares.get(&id) {
+                        audit::record(DeviceKind::ScreenShare, name, &start, &now);
+                    } else if let Some(name) = self.microphones.get(&id) {
+                        audit::record(DeviceKind::Microphone, name, &start, &now);
+                    }
+                }
                 self.screenshares.remove(&id);
                 self.microphones.remove(&id);
             }
@@ -344,6 +407,14 @@ impl Application for PrivacyIndicator {
             Message::KillProcess(pid) => {
                 if let Err(e) = kill(Pid::from_raw(pid.cast_signed()), Signal::SIGTERM) {
                     println!("Failed to kill process {pid}: {e}");
+                }
+            }
+            Message::ToggleAuditLog(enabled) => {
+                self.config.audit_log = enabled;
+                if let Some(handler) = &self.config_handler
+                    && let Err(e) = self.config.write_entry(handler)
+                {
+                    println!("Failed to save audit_log config: {e:?}");
                 }
             }
             Message::Config(config) => self.config = config,

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-//! Local, append-only audit log for privacy events.
-//!
-//! Records only metadata (device kind, application name, start/end/duration).
-//! Never captures audio/video content, never leaves the machine, and the log
-//! file is created with owner-only permissions (0600).
-
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 
+use crate::applet::PrivacyIndicator;
+use cosmic::Application;
 use jiff::Zoned;
 
 #[derive(Debug, Clone, Copy)]
@@ -24,23 +20,20 @@ impl DeviceKind {
     fn label(self) -> &'static str {
         match self {
             DeviceKind::Camera => "CAMERA",
-            DeviceKind::Microphone => "MIC",
-            DeviceKind::ScreenShare => "SCREEN",
+            DeviceKind::Microphone => "MICROPHONE",
+            DeviceKind::ScreenShare => "SCREENSHARE",
         }
     }
 }
 
-/// `$XDG_STATE_HOME/cosmic-ext-applet-privacy-indicator/audit.log`,
-/// falling back to `~/.local/state/...`.
 fn log_path() -> Option<PathBuf> {
     let base = std::env::var_os("XDG_STATE_HOME")
         .map(PathBuf::from)
         .filter(|p| p.is_absolute())
         .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state")))?;
-    Some(base.join("cosmic-ext-applet-privacy-indicator").join("audit.log"))
+    Some(base.join(PrivacyIndicator::APP_ID).join("audit.log"))
 }
 
-/// Human-readable duration, e.g. `45s`, `4m41s`, `1h05m`.
 fn format_duration(secs: i64) -> String {
     let secs = secs.max(0);
     if secs < 60 {
@@ -48,29 +41,21 @@ fn format_duration(secs: i64) -> String {
     } else if secs < 3600 {
         format!("{}m{:02}s", secs / 60, secs % 60)
     } else {
-        format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60)
+        format!("{}h{:02}m{:02}s", secs / 3600, (secs / 60) % 60, secs % 60)
     }
 }
 
-/// Appends one entry to the audit log. `start`/`end` are wall-clock timestamps;
-/// the duration is derived from their UTC instants (DST-safe).
 pub fn record(kind: DeviceKind, app: &str, start: &Zoned, end: &Zoned) {
     let Some(path) = log_path() else {
         eprintln!("audit: could not resolve log path (no XDG_STATE_HOME/HOME)");
         return;
     };
     if let Some(dir) = path.parent() {
-        let _ = fs::create_dir_all(dir);
+        let Ok(_) = fs::create_dir_all(dir) else {
+            eprintln!("audit: could not create log dire");
+            return;
+        };
     }
-
-    let duration = end.timestamp().as_second() - start.timestamp().as_second();
-    let line = format!(
-        "{}  {:<7} {:<14} ({})\n",
-        start.strftime("%Y-%m-%d %H:%M:%S"),
-        kind.label(),
-        app,
-        format_duration(duration),
-    );
 
     match OpenOptions::new()
         .append(true)
@@ -79,10 +64,18 @@ pub fn record(kind: DeviceKind, app: &str, start: &Zoned, end: &Zoned) {
         .open(&path)
     {
         Ok(mut file) => {
+            let duration = end.timestamp().as_second() - start.timestamp().as_second();
+            let line = format!(
+                "{}  {:<7} {:<14} ({})\n",
+                start.strftime("%Y-%m-%d %H:%M:%S"),
+                kind.label(),
+                app,
+                format_duration(duration),
+            );
             if let Err(e) = file.write_all(line.as_bytes()) {
                 eprintln!("audit: failed to write log: {e}");
             }
         }
-        Err(e) => eprintln!("audit: failed to open log {path:?}: {e}"),
+        Err(e) => eprintln!("audit: failed to open log {}: {e}", path.display()),
     }
 }

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Local, append-only audit log for privacy events.
+//!
+//! Records only metadata (device kind, application name, start/end/duration).
+//! Never captures audio/video content, never leaves the machine, and the log
+//! file is created with owner-only permissions (0600).
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
+
+use jiff::Zoned;
+
+#[derive(Debug, Clone, Copy)]
+pub enum DeviceKind {
+    Camera,
+    Microphone,
+    ScreenShare,
+}
+
+impl DeviceKind {
+    fn label(self) -> &'static str {
+        match self {
+            DeviceKind::Camera => "CAMERA",
+            DeviceKind::Microphone => "MIC",
+            DeviceKind::ScreenShare => "SCREEN",
+        }
+    }
+}
+
+/// `$XDG_STATE_HOME/cosmic-ext-applet-privacy-indicator/audit.log`,
+/// falling back to `~/.local/state/...`.
+fn log_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state")))?;
+    Some(base.join("cosmic-ext-applet-privacy-indicator").join("audit.log"))
+}
+
+/// Human-readable duration, e.g. `45s`, `4m41s`, `1h05m`.
+fn format_duration(secs: i64) -> String {
+    let secs = secs.max(0);
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+/// Appends one entry to the audit log. `start`/`end` are wall-clock timestamps;
+/// the duration is derived from their UTC instants (DST-safe).
+pub fn record(kind: DeviceKind, app: &str, start: &Zoned, end: &Zoned) {
+    let Some(path) = log_path() else {
+        eprintln!("audit: could not resolve log path (no XDG_STATE_HOME/HOME)");
+        return;
+    };
+    if let Some(dir) = path.parent() {
+        let _ = fs::create_dir_all(dir);
+    }
+
+    let duration = end.timestamp().as_second() - start.timestamp().as_second();
+    let line = format!(
+        "{}  {:<7} {:<14} ({})\n",
+        start.strftime("%Y-%m-%d %H:%M:%S"),
+        kind.label(),
+        app,
+        format_duration(duration),
+    );
+
+    match OpenOptions::new()
+        .append(true)
+        .create(true)
+        .mode(0o600)
+        .open(&path)
+    {
+        Ok(mut file) => {
+            if let Err(e) = file.write_all(line.as_bytes()) {
+                eprintln!("audit: failed to write log: {e}");
+            }
+        }
+        Err(e) => eprintln!("audit: failed to open log {path:?}: {e}"),
+    }
+}

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -7,9 +7,9 @@ use std::{
 use bimap::BiHashMap;
 use inotify::{Inotify, WatchDescriptor, WatchMask};
 
-use crate::applet::AppInfo;
+use crate::applet::{AppInfo, CameraShares};
 
-pub fn open_cameras() -> HashMap<PathBuf, (i32, i32)> {
+pub fn open_cameras() -> HashMap<PathBuf, CameraShares> {
     if std::path::Path::new("/.flatpak-info").exists() {
         return HashMap::new();
     }
@@ -40,8 +40,10 @@ pub fn open_cameras() -> HashMap<PathBuf, (i32, i32)> {
                         None
                     }
                 })
-                .fold(HashMap::<PathBuf, (i32, i32)>::new(), |mut hm, p| {
-                    hm.entry(p).and_modify(|fds| fds.0 += 1).or_insert((1, 0));
+                .fold(HashMap::<PathBuf, CameraShares>::new(), |mut hm, p| {
+                    hm.entry(p)
+                        .and_modify(|fds| fds.shares += 1)
+                        .or_insert(CameraShares { shares: 1, min: 0 });
                     hm
                 })
         })
@@ -49,6 +51,7 @@ pub fn open_cameras() -> HashMap<PathBuf, (i32, i32)> {
 }
 
 /// Scans /proc to find all processes currently holding a file descriptor open on `device`.
+/// This is CPU intensive. **DO NOT** use in the applet main view.
 pub fn procs_using_camera(device: &Path) -> Vec<AppInfo<'_>> {
     if std::path::Path::new("/.flatpak-info").exists() {
         return vec![];

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,6 @@ pub const CONFIG_VERSION: u64 = 1;
 pub struct Config {
     pub animated: bool,
     pub refresh: u64,
-    /// When enabled, privacy events are appended to a local, owner-only audit
-    /// log. Opt-in: disabled by default.
     pub audit_log: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod applet;
+mod audit;
 mod camera;
 mod rec_icon;
 
@@ -20,6 +21,9 @@ pub const CONFIG_VERSION: u64 = 1;
 pub struct Config {
     pub animated: bool,
     pub refresh: u64,
+    /// When enabled, privacy events are appended to a local, owner-only audit
+    /// log. Opt-in: disabled by default.
+    pub audit_log: bool,
 }
 
 impl Default for Config {
@@ -27,6 +31,7 @@ impl Default for Config {
         Self {
             animated: true,
             refresh: 20,
+            audit_log: false,
         }
     }
 }


### PR DESCRIPTION
Log camera, microphone and screen-share usage (app name, start time and duration) to a local, owner-only file. Disabled by default and toggled from a checkbox in the applet popup. Only metadata is stored and nothing leaves the machine.